### PR TITLE
Add stricter syntax checking for snippets

### DIFF
--- a/CaptureSnippets/Processing/SnippetKeyReader.cs
+++ b/CaptureSnippets/Processing/SnippetKeyReader.cs
@@ -1,13 +1,23 @@
+using System;
+
 static class SnippetKeyReader
 {
     public static bool TryExtractKeyFromLine(string line, out string key)
     {
-        if (line.StartsWith("snippet:"))
+        if (!line.StartsWith("snippet:"))
         {
-            key = line.Substring(8).Trim();
-            return true;
+            key = null;
+            return false;
         }
-        key = null;
-        return false;
+
+        key = line.Substring(8);
+
+        if (!key.StartsWith(" "))
+        {
+            throw new Exception($"Invalid syntax for the snippet '{key}': There must be a space before the start of the key.");
+        }
+
+        key = key.Trim();
+        return true;
     }
 }

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ And the convention method
 The keyed snippets can then be used in any documentation `.md` file by adding the text
 
 ```
-snippet:KEY
+snippet: KEY
 ```
 
 Then snippets with the key (all versions) will be rendered in a tabbed manner. If there is only a single version then it will be rendered as a simple code block with no tabs.

--- a/Tests/MarkdownProcessor_TryExtractKeyFromTests.cs
+++ b/Tests/MarkdownProcessor_TryExtractKeyFromTests.cs
@@ -1,4 +1,5 @@
-﻿using ApprovalTests.Reporters;
+﻿using System;
+using ApprovalTests.Reporters;
 using NUnit.Framework;
 // ReSharper disable StringLiteralTypo
 
@@ -11,8 +12,8 @@ public class MarkdownProcessor_TryExtractKeyFromTests
     public void MissingSpaces()
     {
         string key;
-        SnippetKeyReader.TryExtractKeyFromLine("snippet:snippet", out key);
-        Assert.AreEqual("snippet", key);
+        var exception = Assert.Throws<Exception>(() => SnippetKeyReader.TryExtractKeyFromLine("snippet:snippet", out key));
+        Assert.IsTrue(exception.Message == "Invalid syntax for the snippet 'snippet': There must be a space before the start of the key.");
     }
 
 
@@ -20,7 +21,7 @@ public class MarkdownProcessor_TryExtractKeyFromTests
     public void WithDashes()
     {
         string key;
-        SnippetKeyReader.TryExtractKeyFromLine("snippet:my-code-snippet", out key);
+        SnippetKeyReader.TryExtractKeyFromLine("snippet: my-code-snippet", out key);
         Assert.AreEqual("my-code-snippet", key);
     }
 
@@ -28,7 +29,7 @@ public class MarkdownProcessor_TryExtractKeyFromTests
     public void Simple()
     {
         string key;
-        SnippetKeyReader.TryExtractKeyFromLine("snippet:snippet", out key);
+        SnippetKeyReader.TryExtractKeyFromLine("snippet: snippet", out key);
         Assert.AreEqual("snippet", key);
     }
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -226,6 +226,9 @@
   <ItemGroup>
     <Folder Include="DirectorySnippetExtractor\VerifyLambdasAreCalled\Ignore\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
This PR ensures that the snippet declaration is in the format `snippet: key`, so that there is always a space before the key.